### PR TITLE
Override Kolla-Ansible and set the default Keystone token format to Fernet

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -1,2 +1,8 @@
 ---
 # Add extra Kolla global configuration here.
+
+# Although Kolla-Ansible provides full support for Fernet tokens, it still
+# defaults to UUID.  This setting overrides K-A and brings it in-line with
+# Keystone's default.
+#
+keystone_token_provider: 'fernet'


### PR DESCRIPTION
The addition of this setting overrides K-A's default for Keystone's token driver of UUID, and configures Fernet instead.

Further discussion and backstory to this change is described [over here](https://storyboard.openstack.org/#!/story/2001779).